### PR TITLE
feat: Implement Virtual Gold and Rooms & Realms Tab

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -15,6 +15,7 @@ import type {
 
 // Screens
 import HomeScreen from '@/screens/HomeScreen';
+import RoomsAndRealmsScreen from '../screens/RoomsAndRealmsScreen'; // Import new screen
 import CollectionScreen from '@/screens/CollectionScreen';
 import ScanScreen from '@/screens/ScanScreen';
 import BattleScreen from '@/screens/BattleScreen';
@@ -100,6 +101,9 @@ const MainTabs: React.FC = () => (
           case 'Profile':
             iconName = 'person';
             break;
+          case 'Realms': // Icon for the new tab
+            iconName = 'explore'; // Or 'public' or any other suitable icon
+            break;
           default:
             iconName = 'help';
         }
@@ -129,6 +133,11 @@ const MainTabs: React.FC = () => (
       options={{ title: 'My Miniatures' }}
     />
     <Tab.Screen name="Scan" component={ScanScreen} />
+    <Tab.Screen
+      name="Realms" // Name for the tab bar
+      component={RoomsAndRealmsScreen}
+      options={{ title: 'Rooms and Realms' }} // Title for the header
+    />
     <Tab.Screen name="Battle" component={BattleStackComponent} />
     <Tab.Screen name="Profile" component={ProfileScreen} />
   </Tab.Navigator>

--- a/src/screens/RoomsAndRealmsScreen.tsx
+++ b/src/screens/RoomsAndRealmsScreen.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button, FlatList, ActivityIndicator } from 'react-native';
+import { useSelector, useDispatch } from 'react-redux';
+import { selectUserGold, addGold } from '../../store/slices/userSlice';
+import { useGetQuestsQuery } from '../../store/api';
+import { colors } from '../../utils/theme'; // Assuming theme.ts or theme.js exists
+import type { Quest } from '../../types'; // Import Quest type
+
+const RoomsAndRealmsScreen: React.FC = () => {
+  const userGold = useSelector(selectUserGold);
+  const dispatch = useDispatch();
+  const { data: questsData, isLoading, error } = useGetQuestsQuery();
+
+  const handleCompleteQuest = (goldReward: number) => {
+    dispatch(addGold(goldReward));
+  };
+
+  const renderQuestItem = ({ item }: { item: Quest }) => (
+    <View style={styles.questItemContainer}>
+      <Text style={styles.questTitle}>{item.title}</Text>
+      <Text style={styles.questDescription}>{item.description}</Text>
+      <Text style={styles.questReward}>Reward: {item.goldReward} Gold</Text>
+      <Button title="Complete Quest" onPress={() => handleCompleteQuest(item.goldReward)} color={colors.primary} />
+    </View>
+  );
+
+  let content;
+  if (isLoading) {
+    content = <ActivityIndicator size="large" color={colors.primary} />;
+  } else if (error) {
+    content = <Text style={styles.errorText}>Error loading quests. Please try again later.</Text>;
+  } else if (questsData && questsData.data && questsData.data.length > 0) {
+    content = (
+      <FlatList
+        data={questsData.data}
+        renderItem={renderQuestItem}
+        keyExtractor={(item) => item.id}
+        style={styles.list}
+      />
+    );
+  } else {
+    content = <Text style={styles.questText}>No quests available at the moment.</Text>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Rooms and Realms Screen</Text>
+      <Text style={styles.goldText}>Current Gold: {userGold}</Text>
+      {content}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 20, // Added padding for better layout
+    alignItems: 'center',
+    backgroundColor: colors.background,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: colors.text,
+    marginBottom: 10, // Adjusted margin
+  },
+  goldText: {
+    fontSize: 18,
+    color: colors.primary,
+    marginBottom: 20, // Adjusted margin
+  },
+  questText: { // Re-purposed for 'no quests' message
+    fontSize: 16,
+    color: colors.textSecondary,
+    marginTop: 20,
+  },
+  errorText: {
+    fontSize: 16,
+    color: colors.error, // Assuming colors.error is defined
+    marginTop: 20,
+  },
+  list: {
+    width: '100%',
+    paddingHorizontal: 15,
+  },
+  questItemContainer: {
+    backgroundColor: colors.surface, // Assuming colors.surface is defined
+    padding: 15,
+    borderRadius: 8,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: colors.border, // Assuming colors.border is defined
+  },
+  questTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+    marginBottom: 5,
+  },
+  questDescription: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    marginBottom: 8,
+  },
+  questReward: {
+    fontSize: 14,
+    color: colors.primary,
+    marginBottom: 10,
+  },
+});
+
+export default RoomsAndRealmsScreen;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -8,7 +8,8 @@ import type {
   Miniature,
   Battle,
   User,
-  ApiResponse
+  ApiResponse,
+  Quest // Import the Quest type
 } from '../types';
 import type { RootState } from './index';
 
@@ -26,7 +27,7 @@ export const api = createApi({
       return headers;
     },
   }),
-  tagTypes: ['Miniature', 'Battle', 'User', 'Collection'],
+  tagTypes: ['Miniature', 'Battle', 'User', 'Collection', 'Quest'], // Add 'Quest'
   endpoints: (builder) => ({
     // Authentication endpoints
     login: builder.mutation<LoginResponse, LoginRequest>({
@@ -90,6 +91,18 @@ export const api = createApi({
       query: (userId) => `/battles/history/${userId}`,
       providesTags: ['Battle'],
     }),
+
+    // Quest endpoints
+    getQuests: builder.query<ApiResponse<Quest[]>, void>({
+      query: () => '/quests', // Or '/realms/quests'
+      providesTags: (result) =>
+        result && result.data
+          ? [
+              ...result.data.map(({ id }) => ({ type: 'Quest' as const, id })),
+              { type: 'Quest', id: 'LIST' },
+            ]
+          : [{ type: 'Quest', id: 'LIST' }],
+    }),
   }),
 });
 
@@ -102,4 +115,5 @@ export const {
   useGetUserCollectionQuery,
   useCreateBattleMutation,
   useGetBattleHistoryQuery,
+  useGetQuestsQuery, // Export the new hook
 } = api; 

--- a/src/store/slices/userSlice.ts
+++ b/src/store/slices/userSlice.ts
@@ -15,6 +15,7 @@ const initialState: UserState = {
     battlesLost: 0,
     collectibles: 0,
     achievements: [],
+    gold: 0,
   },
   preferences: {
     soundEnabled: true,
@@ -99,6 +100,12 @@ const userSlice = createSlice({
     clearError: (state) => {
       state.error = null;
     },
+    addGold: (state, action: PayloadAction<number>) => {
+      state.profile.gold += action.payload;
+    },
+    spendGold: (state, action: PayloadAction<number>) => {
+      state.profile.gold = Math.max(0, state.profile.gold - action.payload);
+    },
   },
 });
 
@@ -115,6 +122,8 @@ export const {
   incrementCollectibles,
   setError,
   clearError,
+  addGold,
+  spendGold,
 } = userSlice.actions;
 
 // Selectors
@@ -122,6 +131,7 @@ export const selectUser = (state: RootState): User | null => state.user.user;
 export const selectIsAuthenticated = (state: RootState): boolean => state.user.isAuthenticated;
 export const selectUserLevel = (state: RootState): number => state.user.profile.level;
 export const selectUserExperience = (state: RootState): number => state.user.profile.experiencePoints;
+export const selectUserGold = (state: RootState): number => state.user.profile.gold;
 
 export const selectBattleRecord = (state: RootState) => ({
   won: state.user.profile.battlesWon,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,6 +85,7 @@ export interface UserProfile {
   battlesLost: number;
   collectibles: number;
   achievements: Achievement[];
+  gold: number;
 }
 
 export interface Achievement {
@@ -166,6 +167,15 @@ export interface ConditionEffect {
 export type BattleType = 'standard' | 'tournament' | 'practice' | 'ranked';
 export type BattleStatus = 'waiting' | 'active' | 'completed' | 'abandoned';
 
+// Quest types
+export interface Quest {
+  id: string;
+  title: string;
+  description: string;
+  goldReward: number;
+  // Future fields could include: type, objectives, prerequisites, experienceReward, itemRewards, etc.
+}
+
 // Navigation types
 export type RootStackParamList = {
   Login: undefined;
@@ -178,6 +188,7 @@ export type MainTabParamList = {
   Scan: undefined;
   Battle: undefined;
   Profile: undefined;
+  RoomsAndRealms: undefined;
 };
 
 export type CollectionStackParamList = {


### PR DESCRIPTION
This commit introduces a virtual gold currency system and a new "Rooms and Realms" section.

Key changes:

- **User Profile:**
    - Added a `gold` field to the `UserProfile` type and `userSlice` state.
    - Implemented `addGold` and `spendGold` reducers and a `selectUserGold` selector.

- **Rooms and Realms Screen:**
    - Created a new screen `RoomsAndRealmsScreen.tsx`.
    - Displays your gold balance.
    - Fetches quests from a (currently placeholder) API endpoint `/quests`.
    - Allows you to "complete" quests to earn gold.

- **Navigation:**
    - Added a new "Rooms and Realms" tab to the main bottom tab navigator, linking to the new screen.
    - Uses 'explore' icon for the new tab.

- **API:**
    - Added a `getQuests` API endpoint definition in `api.ts` to fetch quest data.
    - Defined a `Quest` interface for quest data structure.

This provides the foundational framework for the new questing system and virtual currency. Further work will involve connecting to a real external server for quests and implementing the physical location connection for the "Rooms and Realms" tab.